### PR TITLE
Added support for software i2c bus

### DIFF
--- a/SHT3x.h
+++ b/SHT3x.h
@@ -125,8 +125,9 @@
 				SHT3xSensor SensorType = SHT30,
 				SHT3xMode Mode=Single_HighRep_ClockStretch);
 		
-		void Begin();
-		void UpdateData();
+		void Begin( int SDA = 0,
+		            int SCL = 0);
+		void UpdateData(int SDA = 0);
 		
 		float GetTemperature(TemperatureScale Degree = Cel);
 		float GetRelHumidity();
@@ -144,11 +145,11 @@
 		void SetTemperatureCalibrationPoints(CalibrationPoints SensorValues, CalibrationPoints Reference);
 		void SetRelHumidityCalibrationPoints(CalibrationPoints SensorValues, CalibrationPoints Reference);
 
-		void SoftReset();
+		void SoftReset(int SDA = 0);
 		void HardReset();
 		
-		void HeaterOn();
-		void HeaterOff();
+		void HeaterOn(int SDA = 0);
+		void HeaterOff(int SDA = 0);
 		
 		void SetAddress(uint8_t NewAddress);
 		void SetUpdateInterval(uint32_t UpdateIntervalMillisec);
@@ -169,7 +170,7 @@
 		uint32_t _UpdateIntervalMillisec = 500;
 		uint32_t _LastUpdateMillisec = 0;
 		uint32_t _TimeoutMillisec = 100;
-		void SendCommand(uint8_t MSB, uint8_t LSB);
+		void SendCommand(uint8_t MSB, uint8_t LSB, int SDA = 0);
 		bool CRC8(uint8_t MSB, uint8_t LSB, uint8_t CRC);
 		float ReturnValueIfError(float Value);
 		void ToReturnIfError(ValueIfError Value);


### PR DESCRIPTION
The current Wire.h library for use with ESP32 supports the use of a second i2c bus. The desire to use two identical SHT3x probes requires the use of two i2c buses. The original SHT3x library uses only Wire. By defining a second SDA/SCL set and adding Wire1 to the SHT3x library two i2c buses can be used on the eps32.

Use like: 
```c
#include <SHT3x.h>
SHT3x Sensor;
SHT3x Sensor2;

#define SCL_2 17
#define SDA_2 16 

void setup() {
   Serial.begin(115200);
   Sensor.Begin();
   Sensor2.Begin(SDA_2,SCL_2);
}
void loop() {
   Sensor.UpdateData();
   Sensor2.UpdateData(SDA_2);

   Serial.print("Temperature: ");
   Serial.print(Sensor.GetTemperature());
   Serial.write("\xC2\xB0"); //The Degree symbol
   Serial.print("C, ");
   Serial.print("Humidity: ");
   Serial.print(Sensor.GetRelHumidity());
   Serial.println("%");

   Serial.print("Temperature: ");
   Serial.print(Sensor2.GetTemperature());
   Serial.write("\xC2\xB0"); //The Degree symbol
   Serial.print("C, ");
   Serial.print("Humidity: ");
   Serial.print(Sensor2.GetRelHumidity());
   Serial.println("%");

   Serial.println("");
   delay(333);
}
```
The adaption works for me, but I have not studied/checked in depth. This pull request is merely intended as a suggestion.